### PR TITLE
whitelist index.js when publishing NPM module

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   },
   "homepage": "https://github.com/juliangruber/array-filter",
   "main": "index.js",
+  "files": [
+    "index.js"
+  ],
   "scripts": {
     "test": "tape test/*.js"
   },


### PR DESCRIPTION
Hi @juliangruber,

Thanks for your work with this module!

I noticed that the `test` folder and `.travis.yml` are included in the distributed NPM module:
![image](https://user-images.githubusercontent.com/13087421/58371819-7858c580-7f47-11e9-9baa-7ff6357034e0.png)

Hence, in the spirit of keeping the module size small, this PR whitelists `index.js`.